### PR TITLE
Block identifier gas estimates better test

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -53,6 +53,7 @@ Released 2021-04-12
     Default to Berlin
     https://github.com/ethereum/eth-tester/pull/204
 
+
 v0.5.0-beta.2
 -------------
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@ Unreleased
 
   - Reference new public method generate_genesis_state instead of
     protected version in README
+	- Created better test for gas estimate with block identifiers
 
 
 v0.6.0-beta.1
@@ -51,7 +52,6 @@ Released 2021-04-12
   - Upgrade py-evm to v0.4.0-alpha.3, for Berlin support
     Default to Berlin
     https://github.com/ethereum/eth-tester/pull/204
-
 
 v0.5.0-beta.2
 -------------

--- a/eth_tester/tools/gas_burner_contract.py
+++ b/eth_tester/tools/gas_burner_contract.py
@@ -5,13 +5,27 @@ from eth_utils import (
     function_abi_to_4byte_selector,
 )
 
+# The following contract burns gas relative to the current block number. The
+# higher the block number, the more gas is burned. It is used to test
+# functionality that uses block identifiers.
+#
+# pragma solidity >=0.4.22 <0.7.0;
+#
+# contract GasBurner {
+#     uint256 total;
+#     function burnBlockNumberDependentGas() public {
+#         for(uint256 i=0; i<block.number*10; i++) {
+#             total++;
+#         }
+#     }
+# }
 
 GAS_BURNER_BYTECODE = (
-    "6080604052348015600f57600080fd5b5060978061001e6000396000f3fe6080604052348015600f5"
+    "6080604052348015600f57600080fd5b50609b8061001e6000396000f3fe6080604052348015600f5"
     "7600080fd5b506004361060285760003560e01c8063aeecb68814602d575b600080fd5b6033603556"
-    "5b005b60008090505b43811015605f576000808154809291906001019190505550808060010191505"
-    "0603b565b5056fea265627a7a72305820a3f36f9da109907cd816ff48f1fd3bab758923f9dbccbd1a"
-    "0f397cc70ef5423f64736f6c63430005090032"
+    "5b005b60008090505b600a43028110156062576000808154809291906001019190505550808060010"
+    "1915050603b565b5056fea2646970667358221220b69191cdd18045d942bd33c23c74ed334b2604f5"
+    "8490458cc8581e54f8cffed664736f6c63430006060033"
 )
 
 GAS_BURNER_ABI = {

--- a/eth_tester/tools/gas_burner_contract.py
+++ b/eth_tester/tools/gas_burner_contract.py
@@ -5,6 +5,8 @@ from eth_utils import (
     function_abi_to_4byte_selector,
 )
 
+from eth_abi import encode_abi
+
 # The following contract burns gas relative to the current block number. The
 # higher the block number, the more gas is burned. It is used to test
 # functionality that uses block identifiers.
@@ -53,12 +55,7 @@ def _deploy_gas_burner(eth_tester):
     return gas_burner_address
 
 
-def _make_call_gas_burner_transaction(eth_tester, contract_address, fn_name, fn_args=None):
-    from eth_abi import encode_abi
-
-    if fn_args is None:
-        fn_args = tuple()
-
+def _make_call_gas_burner_transaction(eth_tester, contract_address, fn_name, fn_args=tuple()):
     fn_abi = GAS_BURNER_ABI[fn_name]
     arg_types = [
         arg_abi['type']

--- a/eth_tester/utils/backend_testing.py
+++ b/eth_tester/utils/backend_testing.py
@@ -51,7 +51,7 @@ from .throws_contract import (
     _make_call_throws_transaction,
     _decode_throws_result,
 )
-from .gas_burner_contract import (
+from eth_tester.tools.gas_burner_contract import (
     _deploy_gas_burner,
     _make_call_gas_burner_transaction
 )

--- a/eth_tester/utils/backend_testing.py
+++ b/eth_tester/utils/backend_testing.py
@@ -51,6 +51,10 @@ from .throws_contract import (
     _make_call_throws_transaction,
     _decode_throws_result,
 )
+from .gas_burner_contract import (
+    _deploy_gas_burner,
+    _make_call_gas_burner_transaction
+)
 
 PK_A = '0x58d23b55bc9cdce1f18c2500f40ff4ab7245df9a89505e9b1fa4851f623d241d'
 PK_A_ADDRESS = '0xdc544d1aa88ff8bbd2f2aec754b1f1e99e1812fd'
@@ -933,17 +937,17 @@ class BaseTestBackendDirect:
     def test_estimate_gas_with_block_identifier(self, eth_tester):
         self.skip_if_no_evm_execution()
 
-        math_address = _deploy_math(eth_tester)
-        estimate_call_math_transaction = _make_call_math_transaction(
-            eth_tester, math_address, "increment",
+        gas_burner_address = _deploy_gas_burner(eth_tester)
+        estimate_call_gas_burner_transaction = _make_call_gas_burner_transaction(
+            eth_tester, gas_burner_address, "burnBlockNumberDependentGas",
         )
         latest_gas_estimation = eth_tester.estimate_gas(
-            estimate_call_math_transaction, "latest"
+            estimate_call_gas_burner_transaction, "latest"
         )
         earliest_gas_estimation = eth_tester.estimate_gas(
-            estimate_call_math_transaction, "earliest"
+            estimate_call_gas_burner_transaction, "earliest"
         )
-        assert latest_gas_estimation != earliest_gas_estimation
+        assert latest_gas_estimation > earliest_gas_estimation
 
     def test_can_call_after_exception_raised_calling(self, eth_tester):
         self.skip_if_no_evm_execution()

--- a/eth_tester/utils/gas_burner_contract.py
+++ b/eth_tester/utils/gas_burner_contract.py
@@ -1,0 +1,61 @@
+from __future__ import unicode_literals
+
+from eth_utils import (
+    encode_hex,
+    function_abi_to_4byte_selector,
+)
+
+
+GAS_BURNER_BYTECODE = (
+    "6080604052348015600f57600080fd5b5060978061001e6000396000f3fe6080604052348015600f5"
+    "7600080fd5b506004361060285760003560e01c8063aeecb68814602d575b600080fd5b6033603556"
+    "5b005b60008090505b43811015605f576000808154809291906001019190505550808060010191505"
+    "0603b565b5056fea265627a7a72305820a3f36f9da109907cd816ff48f1fd3bab758923f9dbccbd1a"
+    "0f397cc70ef5423f64736f6c63430005090032"
+)
+
+GAS_BURNER_ABI = {
+    "burnBlockNumberDependentGas": {
+        "inputs": [],
+        "name": "burnBlockNumberDependentGas",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    }
+}
+
+
+def _deploy_gas_burner(eth_tester):
+    deploy_hash = eth_tester.send_transaction({
+        "from": eth_tester.get_accounts()[0],
+        "gas": 500000,
+        "data": GAS_BURNER_BYTECODE,
+    })
+    deploy_receipt = eth_tester.get_transaction_receipt(deploy_hash)
+    gas_burner_address = deploy_receipt['contract_address']
+    assert gas_burner_address
+    gas_burner_code = eth_tester.get_code(gas_burner_address)
+    assert len(gas_burner_code) > 2
+    return gas_burner_address
+
+
+def _make_call_gas_burner_transaction(eth_tester, contract_address, fn_name, fn_args=None):
+    from eth_abi import encode_abi
+
+    if fn_args is None:
+        fn_args = tuple()
+
+    fn_abi = GAS_BURNER_ABI[fn_name]
+    arg_types = [
+        arg_abi['type']
+        for arg_abi
+        in fn_abi['inputs']
+    ]
+    fn_selector = function_abi_to_4byte_selector(fn_abi)
+    transaction = {
+        "from": eth_tester.get_accounts()[0],
+        "to": contract_address,
+        "gas": 500000,
+        "data": encode_hex(fn_selector + encode_abi(arg_types, fn_args)),
+    }
+    return transaction


### PR DESCRIPTION
### What was wrong?

The test for the block identifier gas estimates needed improving see #190

### How was it fixed?

I compiled the following contract:

```contract GasBurner {
    uint256 total;
    function burnBlockNumberDependentGas() public {
        for(uint256 i=0; i<block.number; i++) {
            total++; 
        }
    }
}
```

then called burnBlockNumberDependentGas with 'latest' and 'earliest' block identifiers. The results were then checked to ensure the latest estimate was bigger than the earliest.

### To-Do:

- [x] Add entry to the [CHANGELOG](https://github.com/ethereum/eth-tester/blob/master/CHANGELOG)

#### Cute Animal Picture

![Cute animal picture](https://user-images.githubusercontent.com/33668959/94915724-92110200-04d7-11eb-8362-ef1808f2ad5b.jpg)
