### PR TITLE
update deprecated decode calls

### DIFF
--- a/eth_tester/backends/pyevm/main.py
+++ b/eth_tester/backends/pyevm/main.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import time
 
-from eth_abi import decode_single
+from eth_abi import decode
 from eth_abi.exceptions import DecodingError
 
 from eth_account.hdaccount import HDPath, seed_from_mnemonic
@@ -701,7 +701,7 @@ class PyEVMBackend(BaseChainBackend):
             if self.is_eip838_error(computation._error):
                 error_str = computation._error.args[0][36:]
                 try:
-                    msg = decode_single("string", error_str)
+                    msg = decode("string", error_str)
                 except DecodingError:
                     # Invalid encoded bytes, leave msg as computation._error
                     # byte string.

--- a/eth_tester/utils/math_contract.py
+++ b/eth_tester/utils/math_contract.py
@@ -134,9 +134,9 @@ def _make_call_math_transaction(eth_tester, contract_address, fn_name, fn_args=N
 
 
 def _decode_math_result(fn_name, result):
-    from eth_abi import decode_abi
+    from eth_abi import decode
 
     fn_abi = MATH_ABI[fn_name]
     output_types = [output_abi["type"] for output_abi in fn_abi["outputs"]]
 
-    return decode_abi(output_types, decode_hex(result))
+    return decode(output_types, decode_hex(result))

--- a/eth_tester/utils/throws_contract.py
+++ b/eth_tester/utils/throws_contract.py
@@ -139,9 +139,9 @@ def _make_call_throws_transaction(
 
 
 def _decode_throws_result(contract_name, fn_name, result):
-    from eth_abi import decode_abi
+    from eth_abi import decode
 
     fn_abi = THROWS_ABI[contract_name][fn_name]
     output_types = [output_abi["type"] for output_abi in fn_abi["outputs"]]
 
-    return decode_abi(output_types, decode_hex(result))
+    return decode(output_types, decode_hex(result))


### PR DESCRIPTION
### What was wrong?
`eth_abi.decode_abi` and `eth_abi.decode_single` are deprecated. 


### How was it fixed?

Updated to `eth_abi.decode`.

### To-Do:

- [ ] Add entry to the [release notes](https://github.com/ethereum/eth-tester/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/5199899/190009826-179de6bc-8ad1-42d8-b7ef-9bfad818cdc9.png)
