### PR TITLE
Fix ghost blocks

### DIFF
--- a/eth_tester/backends/pyevm/main.py
+++ b/eth_tester/backends/pyevm/main.py
@@ -222,10 +222,11 @@ def _get_block_by_number(chain, block_number):
     elif block_number == "pending":
         return chain.get_block()
     elif is_integer(block_number):
+        # Note: The head block is the pending block. If a block number is passed
+        # explicitly here, return the block only if it is already part of the chain
+        # (i.e. not pending).
         head_block = chain.get_block()
-        if block_number == head_block.number:
-            return head_block
-        elif block_number < head_block.number:
+        if block_number < head_block.number:
             return chain.get_canonical_block_by_number(block_number)
 
     # fallback

--- a/newsfragments/249.breaking.rst
+++ b/newsfragments/249.breaking.rst
@@ -1,0 +1,1 @@
+Pending block may only be retrieved via ``"pending"`` block identifier and not directly by number since it has not yet been "mined" / added to the chain.

--- a/tests/backends/test_pyevm.py
+++ b/tests/backends/test_pyevm.py
@@ -15,7 +15,7 @@ from eth_tester.backends.pyevm.main import (
     get_default_genesis_params,
 )
 from eth_tester.backends.pyevm.utils import is_supported_pyevm_version_available
-from eth_tester.exceptions import ValidationError
+from eth_tester.exceptions import BlockNotFound, ValidationError
 from eth_tester.utils.backend_testing import BaseTestBackendDirect, SIMPLE_TRANSACTION
 
 
@@ -237,3 +237,17 @@ class TestPyEVMBackendDirect(BaseTestBackendDirect):
             self._send_and_check_transaction(
                 eth_tester, SIMPLE_TRANSACTION, ZERO_ADDRESS_HEX
             )
+
+    def test_pending_block_not_found_when_fetched_by_number(self, eth_tester):
+        # assert `latest` block can be fetched by number
+        latest_block_num = eth_tester.get_block_by_number("latest")["number"]
+        assert isinstance(latest_block_num, int)
+        eth_tester.get_block_by_number(latest_block_num)
+
+        # assert `pending` block cannot be fetched by number
+        pending_block_num = eth_tester.get_block_by_number("pending")["number"]
+        assert isinstance(pending_block_num, int)
+        assert pending_block_num == latest_block_num + 1
+
+        with pytest.raises(BlockNotFound):
+            eth_tester.get_block_by_number(pending_block_num)

--- a/tests/backends/test_pyevm.py
+++ b/tests/backends/test_pyevm.py
@@ -219,15 +219,15 @@ class TestPyEVMBackendDirect(BaseTestBackendDirect):
         pyevm_backend = PyEVMBackend(genesis_parameters=genesis_params)
         genesis_block = pyevm_backend.get_block_by_number(0)
         assert genesis_block["gas_limit"] == param_overrides["gas_limit"]
-        genesis_block = pyevm_backend.get_block_by_number(1)
-        assert genesis_block["gas_limit"] == block_one_gas_limit
+        pending_block_one = pyevm_backend.get_block_by_number("pending")
+        assert pending_block_one["gas_limit"] == block_one_gas_limit
 
         # Integrate with EthereumTester
         tester = EthereumTester(backend=pyevm_backend)
         genesis_block = tester.get_block_by_number(0)
         assert genesis_block["gas_limit"] == param_overrides["gas_limit"]
-        genesis_block = tester.get_block_by_number(1)
-        assert genesis_block["gas_limit"] == block_one_gas_limit
+        pending_block_one = tester.get_block_by_number("pending")
+        assert pending_block_one["gas_limit"] == block_one_gas_limit
 
     def test_send_transaction_invalid_from(self, eth_tester):
         accounts = eth_tester.get_accounts()


### PR DESCRIPTION
### What was wrong?

`get_block` methods were able to retrieve the pending block by number before it was added to the chain. This is misleading since the block has not yet been added to the chain. The pending block should only be retrieved via the block identifier `pending`.

### How was it fixed?

- Change logic to only allow the pending block to be retrieved via the `pending` block identifier for `get_block` methods.
- Test for the above changes

### To-Do:

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-tester/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![20221110_182753](https://user-images.githubusercontent.com/3532824/201782132-24242972-7f95-4c75-a9ed-063962dd94d5.jpg)

