### PR TITLE
change name of master branch to main

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,7 @@ Closes #
 
 - [ ] Add or update documentation related to these changes
 
-- [ ] Add entry to the [release notes](https://github.com/ethereum/eth-tester/blob/master/newsfragments/README.md)
+- [ ] Add entry to the [release notes](https://github.com/ethereum/eth-tester/blob/main/newsfragments/README.md)
 
 #### Cute Animal Picture
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Tools for testing Ethereum applications
 
-Read more in the documentation below. [View the change log](https://github.com/ethereum/eth-tester/blob/master/CHANGELOG.rst).
+Read more in the documentation below. [View the change log](https://github.com/ethereum/eth-tester/blob/main/CHANGELOG.rst).
 
 ## Quick Start
 
@@ -105,7 +105,7 @@ The ethereum tester library strictly enforces the following input formats and
 types.
 
 - Hexadecimal values **must** be text (not byte) strings.  The `0x` prefix is optional.
-- Any address which contains mixed-case alpha characters will be validated as a checksummed address as specified by [EIP-55](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-55.md)
+- Any address which contains mixed-case alpha characters will be validated as a checksummed address as specified by [EIP-55](https://github.com/ethereum/ercs/blob/master/ERCS/erc-55.md)
 - 32-byte hashes **must** be hexadecimal encoded.
 - Numeric values **must** be in their integer representation.
 
@@ -967,7 +967,7 @@ The version format for this repo is `{major}.{minor}.{patch}` for stable, and
 
 To issue the next version in line, specify which part to bump,
 like `make release bump=minor` or `make release bump=devnum`. This is typically done from the
-master branch, except when releasing a beta (in which case the beta is released from master,
+main branch, except when releasing a beta (in which case the beta is released from main,
 and the previous stable branch is released from said branch).
 
 If you are in a beta version, `make release bump=stage` will switch to a stable.

--- a/newsfragments/274.internal.rst
+++ b/newsfragments/274.internal.rst
@@ -1,0 +1,1 @@
+Change the name of ``master`` branch to ``main``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ log_format = "%(levelname)8s  %(asctime)s  %(filename)20s  %(message)s"
 log_date_format = "%m-%d %H:%M:%S"
 
 [tool.towncrier]
-# Read https://github.com/ethereum/eth-tester/blob/master/newsfragments/README.md for instructions
+# Read https://github.com/ethereum/eth-tester/blob/main/newsfragments/README.md for instructions
 package = "eth_tester"
 filename = "CHANGELOG.rst"
 directory = "newsfragments"


### PR DESCRIPTION
Change the name of `master` branch to `main`

### Todo:

- [x] Clean up commit history

- [x] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-tester/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/eth-tester/assets/5199899/f2d024fc-9065-467f-a2f3-5279979a3da5)
