### PR TITLE
feat: Python 3.12 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,6 +97,12 @@ jobs:
       - image: cimg/python:3.11
         environment:
           TOXENV: py311-core
+  py312-core:
+    <<: *common
+    docker:
+      - image: cimg/python:3.12
+        environment:
+          TOXENV: py312-core
 
   py38-lint:
     <<: *common
@@ -122,6 +128,12 @@ jobs:
       - image: cimg/python:3.11
         environment:
           TOXENV: py311-lint
+  py312-lint:
+    <<: *common
+    docker:
+      - image: cimg/python:3.12
+        environment:
+          TOXENV: py312-lint
 
   py38-wheel:
     <<: *common
@@ -147,6 +159,12 @@ jobs:
       - image: cimg/python:3.11
         environment:
           TOXENV: py311-wheel
+  py312-wheel:
+    <<: *common
+    docker:
+      - image: cimg/python:3.12
+        environment:
+          TOXENV: py312-wheel
 
   py311-wheel-windows:
     <<: *windows_steps
@@ -177,6 +195,12 @@ jobs:
       - image: cimg/python:3.11
         environment:
           TOXENV: py311-pyevm
+  py312-pyevm:
+    <<: *common
+    docker:
+      - image: cimg/python:3.12
+        environment:
+          TOXENV: py312-pyevm
 
 workflows:
   version: 2
@@ -191,12 +215,15 @@ workflows:
       - py39-lint
       - py310-lint
       - py311-lint
+      - py312-lint
       - py38-wheel
       - py39-wheel
       - py310-wheel
       - py311-wheel
+      - py312-wheel
       - py311-wheel-windows
       - py38-pyevm
       - py39-pyevm
       - py310-pyevm
       - py311-pyevm
+      - py312-pyevm

--- a/eth_tester/backends/pyevm/utils.py
+++ b/eth_tester/backends/pyevm/utils.py
@@ -2,20 +2,26 @@ from __future__ import (
     absolute_import,
 )
 
-import pkg_resources
+import importlib.metadata
+import re
+
 from semantic_version import (
     Version,
 )
 
+# We only care about the release segment of the version. Regexp taken from:
+# https://peps.python.org/pep-0440/#appendix-b-parsing-version-strings-with-regular-expressions
+RELEASE_MATCHER = re.compile(r'^[0-9]+(?:\.[0-9]+)*').match
+
 
 def get_pyevm_version():
     try:
-        base_version = pkg_resources.parse_version(
-            pkg_resources.get_distribution("py-evm").version
-        ).base_version
-        return Version(base_version)
-    except pkg_resources.DistributionNotFound:
+        version = importlib.metadata.version("py-evm")
+    except importlib.metadata.PackageNotFoundError:
         return None
+    else:
+        base_version = RELEASE_MATCHER(version)[0]
+        return Version(base_version)
 
 
 def is_supported_pyevm_version_available():

--- a/setup.py
+++ b/setup.py
@@ -81,5 +81,6 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
 envlist=
-    py{38,39,310,311}-core
-    py{38,39,310,311}-lint
-    py{38,39,310,311}-wheel
+    py{38,39,310,311,312}-core
+    py{38,39,310,311,312}-lint
+    py{38,39,310,311,312}-wheel
     py311-wheel-windows
-    py{38,39,310,311}-pyevm
+    py{38,39,310,311,312}-pyevm
     docs
 
 [flake8]
@@ -20,25 +20,26 @@ commands=
     pyevm: pytest {posargs:tests/backends/test_pyevm.py}
     docs: make docs
 deps =
-    coincurve>=6.0.0
+    coincurve>19.0.0
 basepython=
     docs: python
     py38: python3.8
     py39: python3.9
     py310: python3.10
     py311: python3.11
+    py312: python3.12
 extras=
     test
     docs
     pyevm: py-evm
 allowlist_externals=make,pre-commit
 
-[testenv:py{38,39,310,311}-lint]
+[testenv:py{38,39,310,311,312}-lint]
 deps=pre-commit
 commands=
     pre-commit run --all-files --show-diff-on-failure
 
-[testenv:py{38,39,310,311}-wheel]
+[testenv:py{38,39,310,311,312}-wheel]
 deps=
     wheel
     build[virtualenv]


### PR DESCRIPTION
### What was wrong?

Related to Issue #276
Closes #276

It won't be so easy, we first need to add Python 3.12 support to other parts of the ecosystem:

- ethereum/eth-rlp#17
- ethereum/eth-rlp#18
- ofek/coincurve#133 (the v19.0.0, bringing Python 3.12 support, was yanked because of an issue on Windows)
- ethereum/blake2b-py#22

### How was it fixed?

### Todo:

- [ ] Clean up commit history

- [ ] Add or update documentation related to these changes

- [ ] Add entry to the [release notes](https://github.com/ethereum/eth-tester/blob/main/newsfragments/README.md)
