### PR TITLE
[0.9] correctly convert hex to int base 16

### DIFF
--- a/eth_tester/normalization/inbound.py
+++ b/eth_tester/normalization/inbound.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 from eth_utils import (
-    remove_0x_prefix,
     to_bytes,
 )
 from eth_utils.curried import (
@@ -93,7 +92,7 @@ def _normalize_inbound_access_list(access_list):
             tuple(
                 [
                     to_bytes(hexstr=entry["address"]),
-                    tuple([int(remove_0x_prefix(k)) for k in entry["storage_keys"]]),
+                    tuple([int(k, 16) for k in entry["storage_keys"]]),
                 ]
             )
             for entry in access_list

--- a/newsfragments/282.bugfix.rst
+++ b/newsfragments/282.bugfix.rst
@@ -1,0 +1,1 @@
+Properly convert access list storage keys to ``int`` with base 16.

--- a/tests/core/normalization/test_inbound_normalization.py
+++ b/tests/core/normalization/test_inbound_normalization.py
@@ -1,0 +1,32 @@
+from eth_tester.normalization.inbound import (
+    _normalize_inbound_access_list,
+)
+
+
+def test_inbound_access_list_normalization():
+    inbound_access_list = [
+        {
+            "address": "0x52908400098527886E0F7030069857D2E4169EE7",
+            "storage_keys": [f"0x{'00' * 30}3039", f"0x{'00' * 30}0539"],
+        },
+        {
+            "address": "0x8617E340B3D01FA5F11F306F4090FD50E238070D",
+            "storage_keys": [],
+        },
+        {
+            "address": f"0x{'00' * 20}",
+            "storage_keys": [f"0x{'00' * 28}499602d2"],
+        },
+    ]
+    expected = (
+        (
+            b"R\x90\x84\x00\t\x85'\x88n\x0fp0\x06\x98W\xd2\xe4\x16\x9e\xe7",
+            (12345, 1337),
+        ),
+        (
+            b"\x86\x17\xe3@\xb3\xd0\x1f\xa5\xf1\x1f0o@\x90\xfdP\xe28\x07\r",
+            (),
+        ),
+        (b"\x00" * 20, (1234567890,)),
+    )
+    assert _normalize_inbound_access_list(inbound_access_list) == expected


### PR DESCRIPTION
### What was wrong?

backport of #281 

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-tester/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![20240125_163926](https://github.com/ethereum/eth-tester/assets/3532824/c4538f6e-de87-4538-906a-c36a46bf9b9d)