### PR TITLE
Update `py-evm` dependency to v0.9.0b1

### DIFF
--- a/newsfragments/283.misc.rst
+++ b/newsfragments/283.misc.rst
@@ -1,0 +1,1 @@
+Bump `py-evm` to `0.9.0b1`

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ extras_require = {
     "py-evm": [
         # Pin py-evm to exact version, until it leaves alpha.
         # EVM is very high velocity and might change API at each alpha.
-        "py-evm==0.7.0a4",
+        "py-evm==0.9.0b1",
         "eth-hash[pysha3]>=0.1.4,<1.0.0;implementation_name=='cpython'",
         "eth-hash[pycryptodome]>=0.1.4,<1.0.0;implementation_name=='pypy'",
     ],


### PR DESCRIPTION
### What was wrong?

Related to Issue ethereum/web3.py#715

Update to unpinned version of `eth-utils` in `py-evm` so that `eth-utils` can be updated in web3.py `v7`.

### How was it fixed?

Updated `setup.py` with `py-evm==0.9.0b1`

### Todo:

- [x] Clean up commit history

- [x] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/eth-tester/blob/main/newsfragments/README.md)

#### Cute Animal Picture
<img width="392" alt="Screen Shot 2024-02-22 at 4 25 21 PM" src="https://github.com/ethereum/eth-tester/assets/435903/0aa985cb-450c-40d2-bbfc-f7f89d276fcd">



