### PR TITLE
eth-account bugfix to remove pydantic dependency; might as well use it

### DIFF
--- a/newsfragments/287.internal.rst
+++ b/newsfragments/287.internal.rst
@@ -1,0 +1,1 @@
+Bump `eth-account` to ``>=0.11.2`` since there was a dependency-related bugfix.

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "eth-abi>=3.0.1",
-        "eth-account>=0.11.1",
+        "eth-account>=0.11.2",
         "eth-keys>=0.4.0",
         "eth-utils>=2.0.0",
         "rlp>=3.0.0",


### PR DESCRIPTION
### What was wrong?

This is technically not necessary but since *eth-account* had a dependency bugfix let's avoid any sort of issues altogether by lower-pinning cancun support for eth-account beyond the bugfix.

### How was it fixed?

- use `eth-account>=0.11.2` (bugfix patch release that removes the dependency on pydantic introduced in `0.11.1`)

### Todo:

- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-tester/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![](https://external-content.duckduckgo.com/iu/?u=http%3A%2F%2Fwww.pixelstalk.net%2Fwp-content%2Fuploads%2F2016%2F03%2FFree-cute-animal-wallpaper-HD.jpg&f=1&nofb=1&ipt=aa71c0a7dc5e449befb680034a60c46f7376bc714767c25db161310817b1049c&ipo=images)
