### PR TITLE
feat: remove setuptools dependency

### DIFF
--- a/eth_tester/backends/pyevm/utils.py
+++ b/eth_tester/backends/pyevm/utils.py
@@ -2,14 +2,19 @@ from __future__ import (
     absolute_import,
 )
 
+from importlib.metadata import (
+    PackageNotFoundError,
+    version,
+)
 from typing import (
     Any,
     Dict,
     Union,
 )
 
-from importlib.metadata import version, PackageNotFoundError
-from semantic_version import Version
+from semantic_version import (
+    Version,
+)
 
 
 def get_pyevm_version():

--- a/eth_tester/backends/pyevm/utils.py
+++ b/eth_tester/backends/pyevm/utils.py
@@ -8,19 +8,21 @@ from typing import (
     Union,
 )
 
-import pkg_resources
-from semantic_version import (
-    Version,
-)
+from importlib.metadata import version, PackageNotFoundError
+from semantic_version import Version
 
 
 def get_pyevm_version():
     try:
-        base_version = pkg_resources.parse_version(
-            pkg_resources.get_distribution("py-evm").version
-        ).base_version
-        return Version(base_version)
-    except pkg_resources.DistributionNotFound:
+        # Fetch the version string of py-evm from its metadata
+        base_version = version("py-evm")
+        # Create a Version instance from the semantic version library
+        return Version.coerce(base_version)
+    except PackageNotFoundError:
+        print("Package 'py-evm' not found.")
+        return None
+    except ValueError as ve:
+        print(f"Version parsing error: {ve}")
         return None
 
 

--- a/newsfragments/288.internal.rst
+++ b/newsfragments/288.internal.rst
@@ -1,0 +1,1 @@
+Drop ``pkg_resources`` in favor of ``importlib.metadata`` for getting ``pyevm`` version


### PR DESCRIPTION
### What was wrong?

using pkg_resources which comes from setuptools disallows me from installing ape with `uv` without adding setuptools as a regular dependency to ape.
working toward fully removed dependence on setuptools in ape, tracking PR here: https://github.com/ApeWorX/ape/pull/2003
also, moving away from pkg_resources is best practice. its features are now available in the standard library.

### How was it fixed?

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-tester/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](<https://github.com/ethereum/eth-tester/assets/16990562/0e4ee449-339b-4d62-9d38-935b3ce4ca05>)
