### PR TITLE
makefile use zsh-compatible escape characters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ notes: check-bump
 
 release: check-bump clean
 	# require that upstream is configured for ethereum/eth-tester
-	git remote -v | grep "upstream\tgit@github.com:ethereum/eth-tester.git (push)\|upstream\thttps://github.com/ethereum/eth-tester (push)"
+	git remote -v | grep -E 'upstream[[:blank:]]+git@github.com:ethereum/eth-tester.git \(push\)|upstream[[:blank:]]+https://github.com/ethereum/eth-tester (push)'
 	# verify that docs build correctly
 	./newsfragments/validate_files.py is-empty
 	make docs

--- a/newsfragments/289.internal.rst
+++ b/newsfragments/289.internal.rst
@@ -1,0 +1,1 @@
+Make ``make release`` work on zsh by using more general ``grep`` command


### PR DESCRIPTION
### What was wrong?

`make release` errors due to escape characters on zsh:

```
git remote -v | grep "upstream\tgit@github.com:ethereum/eth-tester.git (push)\|upstream\thttps://github.com/ethereum/eth-tester (push)"
grep: warning: stray \ before t
grep: warning: stray \ before t
```

### How was it fixed?

ask gpt to make it zsh-compatible:

```
git remote -v | grep -E 'upstream[[:blank:]]+git@github.com:ethereum/eth-tester.git \(push\)|upstream[[:blank:]]+https://github.com/ethereum/eth-tester (push)'
upstream	git@github.com:ethereum/eth-tester.git (push)
bash
git remote -v | grep -E 'upstream[[:blank:]]+git@github.com:ethereum/eth-tester.git \(push\)|upstream[[:blank:]]+https://github.com/ethereum/eth-tester (push)'
upstream	git@github.com:ethereum/eth-tester.git (push)
```

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-tester/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="704" alt="image" src="https://github.com/ethereum/eth-tester/assets/16990562/4da0cf1f-5fef-4bb6-b0a2-1021667ba223">

