### PR TITLE
delete py.typed file, remove from package info

### DIFF
--- a/newsfragments/292.internal.rst
+++ b/newsfragments/292.internal.rst
@@ -1,0 +1,1 @@
+Remove ``py.typed`` file, as lib is not typed

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,6 @@ setup(
     zip_safe=False,
     keywords="ethereum",
     packages=find_packages(exclude=["scripts", "scripts.*", "tests", "tests.*"]),
-    package_data={"eth_tester": ["py.typed"]},
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",
         "Intended Audience :: Developers",


### PR DESCRIPTION
### What was wrong?

A `py.typed` file snuck into an un-typed lib. Removing.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-tester/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/eth-tester/assets/5199899/5985476e-c7d2-49fe-94d6-c1e5a7728bc6)
