### PR TITLE
bugfix: `eth_call` for pyevm should not check for known account 

### DIFF
--- a/eth_tester/backends/pyevm/main.py
+++ b/eth_tester/backends/pyevm/main.py
@@ -873,14 +873,15 @@ class PyEVMBackend(BaseChainBackend):
         if "gas" not in defaulted_transaction:
             defaulted_transaction["gas"] = self._max_available_gas()
 
-        signed_evm_transaction = self._get_normalized_and_signed_evm_transaction(
+        unsigned_tx = self._get_normalized_and_unsigned_evm_transaction(
             defaulted_transaction,
             block_number,
         )
+        evm_transaction = EVMSpoofTransaction(unsigned_tx, from_=transaction["from"])
 
         computation = _execute_and_revert_transaction(
             self.chain,
-            signed_evm_transaction,
+            evm_transaction,
             block_number,
         )
         if computation.is_error:

--- a/newsfragments/297.bugfix.rst
+++ b/newsfragments/297.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug where requests for ``eth_call`` via *PyEVMBackend* fail with invalid ``from`` key. The account need not be a "known" account for signing since eth_call does not change the state of the blockchain.

--- a/tests/backends/test_pyevm.py
+++ b/tests/backends/test_pyevm.py
@@ -491,3 +491,28 @@ class TestPyEVMBackendDirect(BaseTestBackendDirect):
 
         with pytest.raises(EthUtilsValidationError):
             acct.sign_transaction(tx, blobs=[blob_data])
+
+    def test_eth_call_does_not_require_a_known_account(self, eth_tester):
+        # `eth_call` should not require the `from` address to be a known account
+        # as it does not change the state of the blockchain
+        acct = Account.create()
+
+        # fund acct
+        eth_tester.send_transaction(
+            {
+                "from": eth_tester.get_accounts()[0],
+                "to": acct.address,
+                "value": 10**18,
+                "gas": 21000,
+            }
+        )
+
+        result = eth_tester.call(
+            {
+                "from": acct.address,
+                "to": eth_tester.get_accounts()[0],
+                "data": "0x",
+            }
+        )
+
+        assert result == "0x"


### PR DESCRIPTION
### What was wrong?

closes https://github.com/ethereum/web3.py/issues/2198

### How was it fixed?

- Build an unsigned, spoofed tx rather than a signed tx for `eth_call` via *py-evm*. The account should not need to be a known account since we aren't signing for `eth_call` because it does not change state.

### Todo:

- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-tester/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![1000026487](https://github.com/user-attachments/assets/d01b4ff0-8ccf-4b79-a368-aa61e461e830)
