### PR TITLE
update estimate_gas interface everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,9 +509,10 @@ value from the evm.
 
 <a id="api-estimate_gas"></a>
 
-#### `EthereumTester.estimate_gas(transaction)`
+#### `EthereumTester.estimate_gas(transaction, block_number='latest')`
 
-Executes the provided `transaction` object, measuring and returning the gas
+Executes the provided `transaction` object at the evm state from the block
+denoted by the `block_number` parameter, measuring and returning the gas
 consumption.
 
 <a id="api-fee_history"></a>

--- a/eth_tester/backends/mock/main.py
+++ b/eth_tester/backends/mock/main.py
@@ -317,7 +317,7 @@ class MockBackend(BaseChainBackend):
         transaction = dissoc(signed_transaction, "r", "s", "v")
         return self.send_transaction(transaction)
 
-    def estimate_gas(self, transaction):
+    def estimate_gas(self, transaction, block_number="latest"):
         raise NotImplementedError("Must be implemented by subclasses")
 
     def call(self, transaction, block_number="latest"):

--- a/newsfragments/298.bugfix.rst
+++ b/newsfragments/298.bugfix.rst
@@ -1,0 +1,1 @@
+Add missing ``block_number`` arg to ``MockBackend`` ``estimate_gas`` and test.

--- a/newsfragments/298.docs.rst
+++ b/newsfragments/298.docs.rst
@@ -1,0 +1,1 @@
+Add missing ``block_number`` arg to ``estimate_gas`` documentation.

--- a/tests/core/test_mock_backend.py
+++ b/tests/core/test_mock_backend.py
@@ -15,9 +15,25 @@ def eth_tester():
     return EthereumTester(backend=backend)
 
 
+@pytest.fixture
+def test_transaction():
+    return {
+        "from": "0x" + "1" * 40,
+        "to": "0x" + "2" * 40,
+        "gas": 21000,
+        "value": 1000000000000000000,
+        "data": "0x1234",
+        "nonce": 0,
+    }
+
+
 class TestMockBackendDirect(BaseTestBackendDirect):
     supports_evm_execution = False
 
     @pytest.mark.skip(reason="receipt status not supported in MockBackend")
     def test_get_transaction_receipt_byzantium(self, eth_tester, test_transaction):
         pass
+
+    def test_estimate_gas_raises_not_implemented(self, eth_tester, test_transaction):
+        with pytest.raises(NotImplementedError):
+            eth_tester.estimate_gas(test_transaction, block_number="pending")


### PR DESCRIPTION
### What was wrong?

Documentation and mock interfaces still use the old format, while the actual implementation uses the new interface already.

Closes #181

### How was it fixed?

Update documentation and mock interface by add optional `block_number` parameter.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-tester/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.imgur.com/CiGOnGP.jpeg)
