### PR TITLE
Fix typo Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ with open("./README.md") as readme:
 
 setup(
     name="eth-tester",
-    # *IMPORTANT*: Don't manually change the version here. Use the 'bumpversion' utility.
+    # *IMPORTANT*: Don't manually change the version here. Use the 'bump2version' utility.
     version="0.12.0-beta.2",
     description="""eth-tester: Tools for testing Ethereum applications.""",
     long_description=long_description,


### PR DESCRIPTION
### What was wrong?

A typo in the comment within setup.py, where the outdated tool name bumpversion is referenced.

The correct tool name is **bump2version**, as bumpversion is no longer maintained.

### How was it fixed?

`# *IMPORTANT*: Don't manually change the version here. Use the 'bump2version' utility. `

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-tester/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Enjoy](https://smv.org/media/images/2021.03.10_AnimalCuteness_Getty.width-1000.jpg)
